### PR TITLE
Fix: Correct public path for Vercel build

### DIFF
--- a/tenant-management-app/public
+++ b/tenant-management-app/public
@@ -1,1 +1,0 @@
-<!-- This file is intentionally left blank. -->

--- a/tenant-management-app/public/vite.svg
+++ b/tenant-management-app/public/vite.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#646cff" />
+</svg>


### PR DESCRIPTION
This commit fixes a build error on Vercel caused by the `public` path being a file instead of a directory.

The changes are:
- The incorrect `public` file has been deleted.
- A new `public` directory has been created.
- A placeholder `vite.svg` has been added to the `public` directory to resolve the reference in `index.html`.

This should resolve the `ENOTDIR` error during the Vercel build process.