### PR TITLE
Fix: Add missing Tailwind CSS configuration

### DIFF
--- a/tenant-management-app/postcss.config.js
+++ b/tenant-management-app/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/tenant-management-app/tailwind.config.js
+++ b/tenant-management-app/tailwind.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  purge: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  darkMode: false, // or 'media' or 'class'
+  theme: {
+    extend: {},
+  },
+  variants: {
+    extend: {},
+  },
+  plugins: [],
+}


### PR DESCRIPTION
This commit adds the missing `tailwind.config.js` and `postcss.config.js` files. These files are required for Tailwind CSS to work correctly with Vite.

The absence of these files was causing the styling to be missing on the deployed Vercel application. Adding them should resolve the issue.