### PR TITLE
Fix: Add missing postcss and autoprefixer dependencies

### DIFF
--- a/tenant-management-app/package.json
+++ b/tenant-management-app/package.json
@@ -18,6 +18,8 @@
   "devDependencies": {
     "vite": "^3.2.11",
     "typescript": "^4.0.0",
-    "@vitejs/plugin-react": "^2.2.0"
+    "@vitejs/plugin-react": "^2.2.0",
+    "postcss": "^8.4.38",
+    "autoprefixer": "^10.4.19"
   }
 }


### PR DESCRIPTION
This commit adds `postcss` and `autoprefixer` to the `devDependencies`. These packages are required peer dependencies for Tailwind CSS v2, and their absence was causing the styling to not be applied during the Vercel build.