### PR TITLE
fix: Restore Tailwind CSS styling after config reorganization

### DIFF
--- a/tenant-management-app-v2/config/postcss.config.cjs
+++ b/tenant-management-app-v2/config/postcss.config.cjs
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: {
-    tailwindcss: {},
+    tailwindcss: { config: './config/tailwind.config.cjs' },
     autoprefixer: {},
   },
 }

--- a/tenant-management-app-v2/vite.config.js
+++ b/tenant-management-app-v2/vite.config.js
@@ -4,4 +4,7 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  css: {
+    postcss: './config/postcss.config.cjs'
+  }
 })


### PR DESCRIPTION
- Update PostCSS config to reference new Tailwind config path
- Configure Vite to use relocated PostCSS config file
- Test build process confirms styling is working properly
- CSS bundle generates correctly (24.79 kB)

Fixes styling issues introduced by repository reorganization.

🤖 Generated with [Claude Code](https://claude.ai/code)