### PR TITLE
feat: Add Vercel Speed Insights

### DIFF
--- a/tenant-management-app-v2/package-lock.json
+++ b/tenant-management-app-v2/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.54.0",
+        "@vercel/speed-insights": "^1.2.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-router-dom": "^7.8.0",
@@ -1924,6 +1925,41 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-1.2.0.tgz",
+      "integrity": "sha512-y9GVzrUJ2xmgtQlzFP2KhVRoCglwfRQgjyfY607aU0hh0Un6d0OUyrJkjuAlsV18qR4zfoFPs/BiIj9YDS6Wzw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitejs/plugin-react": {

--- a/tenant-management-app-v2/package.json
+++ b/tenant-management-app-v2/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.54.0",
+    "@vercel/speed-insights": "^1.2.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.8.0",

--- a/tenant-management-app-v2/src/App.jsx
+++ b/tenant-management-app-v2/src/App.jsx
@@ -16,6 +16,7 @@ import ErrorBoundary from './components/ErrorBoundary'
 import LogMonitor from './components/debug/LogMonitor'
 import logger from './services/logger'
 import { useLogger } from './hooks/useLogger'
+import { SpeedInsights } from '@vercel/speed-insights/react'
 
 function App() {
   const { user, loading, checkAuth } = useAuthStore()
@@ -155,6 +156,7 @@ function App() {
           </button>
         </div>
       )}
+      <SpeedInsights />
     </Router>
     </ErrorBoundary>
   )


### PR DESCRIPTION
This commit adds Vercel Speed Insights to the tenant-management-app-v2 project to enable performance monitoring.

- Installs the `@vercel/speed-insights` package.
- Integrates the `<SpeedInsights />` component into the root `App.jsx` file, importing it from `@vercel/speed-insights/react`.