### PR TITLE
feat: Simplify and change property types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "app",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/tenant-management-app-v2/package-lock.json
+++ b/tenant-management-app-v2/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.54.0",
+        "@vercel/analytics": "^1.5.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-router-dom": "^7.8.0",
@@ -1924,6 +1925,44 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.5.0.tgz",
+      "integrity": "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitejs/plugin-react": {

--- a/tenant-management-app-v2/src/__tests__/components/forms/AddPropertyForm.test.jsx
+++ b/tenant-management-app-v2/src/__tests__/components/forms/AddPropertyForm.test.jsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import AddPropertyForm from '../../../components/forms/AddPropertyForm'
+
+describe('AddPropertyForm', () => {
+  it('renders correctly', () => {
+    render(<AddPropertyForm onSuccess={() => {}} onCancel={() => {}} />)
+    expect(screen.getByLabelText('Property Name')).toBeInTheDocument()
+  })
+})

--- a/tenant-management-app-v2/src/components/forms/AddPropertyForm.jsx
+++ b/tenant-management-app-v2/src/components/forms/AddPropertyForm.jsx
@@ -3,14 +3,7 @@ import { propertiesService } from '../../services/properties'
 import Input from '../ui/Input'
 import Select from '../ui/Select'
 import Button from '../ui/Button'
-
-const PROPERTY_TYPES = [
-  { value: 'apartment', label: 'Apartment Complex' },
-  { value: 'house', label: 'Single Family House' },
-  { value: 'duplex', label: 'Duplex' },
-  { value: 'commercial', label: 'Commercial Building' },
-  { value: 'condo', label: 'Condominium' }
-]
+import { PROPERTY_TYPES } from '../../utils/constants'
 
 export default function AddPropertyForm({ onSuccess, onCancel }) {
   const [formData, setFormData] = useState({

--- a/tenant-management-app-v2/src/components/forms/EditPropertyForm.jsx
+++ b/tenant-management-app-v2/src/components/forms/EditPropertyForm.jsx
@@ -3,14 +3,7 @@ import { propertiesService } from '../../services/properties'
 import Input from '../ui/Input'
 import Select from '../ui/Select'
 import Button from '../ui/Button'
-
-const PROPERTY_TYPES = [
-  { value: 'apartment', label: 'Apartment Complex' },
-  { value: 'house', label: 'Single Family House' },
-  { value: 'duplex', label: 'Duplex' },
-  { value: 'commercial', label: 'Commercial Building' },
-  { value: 'condo', label: 'Condominium' }
-]
+import { PROPERTY_TYPES } from '../../utils/constants'
 
 export default function EditPropertyForm({ property, onSuccess, onCancel }) {
   const [formData, setFormData] = useState({

--- a/tenant-management-app-v2/src/utils/constants.js
+++ b/tenant-management-app-v2/src/utils/constants.js
@@ -30,3 +30,11 @@ export const LEASE_STATUSES = {
   COMPLETED: 'completed',
   TERMINATED: 'terminated'
 }
+
+export const PROPERTY_TYPES = [
+  { value: 'Terrace House', label: 'Terrace House' },
+  { value: 'Apartment/Flat', label: 'Apartment/Flat' },
+  { value: 'Condominium/Serviced Residence', label: 'Condominium/Serviced Residence' },
+  { value: 'Semi-Detached House (Semi-D)', label: 'Semi-Detached House (Semi-D)' },
+  { value: 'Bungalow/Detached House', label: 'Bungalow/Detached House' }
+]


### PR DESCRIPTION
Simplifies and changes the property types to a new list.
- Centralizes the `PROPERTY_TYPES` constant in `src/utils/constants.js`.
- Updates `AddPropertyForm.jsx` and `EditPropertyForm.jsx` to use the new constant.
- Adds a test file for `AddPropertyForm.jsx`.